### PR TITLE
Full multi-node support for completions and annotations

### DIFF
--- a/activeuf/configs.py
+++ b/activeuf/configs.py
@@ -96,7 +96,11 @@ PRINCIPLES = [
     "honesty",
     "truthfulness",
 ]
-DEFAULT_PRINCIPLE = "helpfulness"
+DEFAULT_PRINCIPLES = [
+    "helpfulness",
+    "honesty",
+    "truthfulness",
+]
 
 # System prompts to be used when generating completions
 PRINCIPLE2SYSTEM_PROMPTS = {

--- a/activeuf/configs.py
+++ b/activeuf/configs.py
@@ -8,12 +8,13 @@ LOGS_DIR = "logs"
 SEED = 123
 MAX_NUM_GPUS = 4
 MAX_NUM_NODES = 1
+DATA_PARALLEL_SIZE = 1  # Only compatible with "vllm_server" model class
 MAX_API_RETRY = 10
 # Which package to use for the model. ["transformers", "pipeline" "vllm", "vllm_server"]
 DEFAULT_MODEL_CLASS = "vllm"
 
 VLLM_SERVER_BASE_URL = "http://localhost:8000"  # URL of the vLLM server
-PING_DELAY = 10        # Delay between pings to the server to check if it is already running
+PING_DELAY = 30        # Delay between pings to the server to check if it is already running
 MAX_PING_RETRIES = 30  # Number of retries to check if the server is running
 
 # ====================================

--- a/activeuf/configs.py
+++ b/activeuf/configs.py
@@ -15,7 +15,7 @@ DEFAULT_MODEL_CLASS = "vllm"
 
 VLLM_SERVER_BASE_URL = "http://localhost:8000"  # URL of the vLLM server
 PING_DELAY = 30        # Delay between pings to the server to check if it is already running
-MAX_PING_RETRIES = 30  # Number of retries to check if the server is running
+MAX_PING_RETRIES = 100  # Number of retries to check if the server is running
 
 # ====================================
 #               DATASETS
@@ -71,7 +71,7 @@ COMPLETION_MODEL_NAMES = {
 
     # ===== MoE MODELS =====
     "meta-llama/Llama-4-Scout-17B-16E-Instruct",     # 109B (17B Active)
-    "meta-llama/Llama-4-Maverick-17B-128E-Instruct",  # 402B (17B Active)
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct", # 402B (17B Active)
 
     "Qwen/Qwen3-30B-A3B",                            # 30B  (03B Active)
     "Qwen/Qwen3-235B-A22B",                          # 235B (22B Active)
@@ -136,12 +136,7 @@ MAX_API_RETRY = 10
 MAX_PARSE_RETRY = 10
 
 # Aspects to be used to annotate the generated completions
-ASPECTS = [
-    "instruction_following",
-    "helpfulness",
-    "honesty",
-    "truthfulness"
-]
+ASPECTS = ["instruction_following", "helpfulness", "honesty", "truthfulness"]
 
 # Map an aspect to the corresponding system prompt (template) that is used to annotate the generated completions
 # ASPECT2ANNOTATION_PROMPT = {

--- a/activeuf/convert_to_preference.py
+++ b/activeuf/convert_to_preference.py
@@ -63,10 +63,12 @@ def convert_to_ultrafeedback(sample):
     return {
         "prompt": sample["prompt"],
         "prompt_id": sample["prompt_id"],
-        "chosen": chosen_completion["response_text"],
-        "chosen_model": chosen_completion["model"],
         "rejected": rejected_completions["response_text"],
         "rejected_model": rejected_completions["model"],
+        "rejected_score": rejected_completions["overall_score"],
+        "chosen": chosen_completion["response_text"],
+        "chosen_model": chosen_completion["model"],
+        "chosen_score": chosen_completion["overall_score"],
     }
 
 def convert_to_random(sample):
@@ -93,8 +95,10 @@ def convert_to_random(sample):
         "prompt_id": sample["prompt_id"],
         "chosen": chosen_completion["response_text"],
         "chosen_model": chosen_completion["model"],
+        "chosen_score": chosen_completion["overall_score"],
         "rejected": rejected_completion["response_text"],
         "rejected_model": rejected_completion["model"],
+        "rejected_score": rejected_completion["overall_score"],
     }
 
 

--- a/activeuf/generate_completions.py
+++ b/activeuf/generate_completions.py
@@ -39,7 +39,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--num_nodes", type=int, default=os.getenv("SLURM_NNODES", 1), help="The maximum number of nodes to use for distributed training (if applicable)")
     parser.add_argument("--data_parallel_size", type=int, default=DATA_PARALLEL_SIZE, help="The size of the data parallel group (only applicable for vllm_server model class)")
     parser.add_argument("--max_tokens", type=int, default=COMPLETION_MAX_TOKENS, help="The maximum number of tokens to generate for each completion")
-    parser.add_argument("--max_model_len", type=int, default=MAX_MODEL_LEN, help="The maximum context length of the model")
+    parser.add_argument("--max_model_len", type=int, default=0, help="The maximum context length of the model")
+    parser.add_argument("--gpu_memory_utilization", type=float, default=0.9, help="The GPU memory utilization to use for loading the model (only used for vllm models)")
     parser.add_argument("--temperature", type=int, default=COMPLETION_TEMPERATURE, help="Temperature for generation")
     parser.add_argument("--top_p", type=int, default=COMPLETION_TOP_P, help="top_p value for generation")
     parser.add_argument("--seed", type=int, default=SEED, help="Seed for random sampling")
@@ -110,6 +111,7 @@ if __name__ == "__main__":
         num_nodes=args.num_nodes,
         data_parallel_size=args.data_parallel_size,
         max_model_len=args.max_model_len,
+        gpu_memory_utilization=args.gpu_memory_utilization,
     )
     sampling_params = vllm.SamplingParams(
         max_tokens=args.max_tokens,

--- a/activeuf/generate_completions.py
+++ b/activeuf/generate_completions.py
@@ -39,6 +39,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--num_nodes", type=int, default=os.getenv("SLURM_NNODES", 1), help="The maximum number of nodes to use for distributed training (if applicable)")
     parser.add_argument("--data_parallel_size", type=int, default=DATA_PARALLEL_SIZE, help="The size of the data parallel group (only applicable for vllm_server model class)")
     parser.add_argument("--max_tokens", type=int, default=COMPLETION_MAX_TOKENS, help="The maximum number of tokens to generate for each completion")
+    parser.add_argument("--max_model_len", type=int, default=MAX_MODEL_LEN, help="The maximum context length of the model")
     parser.add_argument("--temperature", type=int, default=COMPLETION_TEMPERATURE, help="Temperature for generation")
     parser.add_argument("--top_p", type=int, default=COMPLETION_TOP_P, help="top_p value for generation")
     parser.add_argument("--seed", type=int, default=SEED, help="Seed for random sampling")
@@ -103,11 +104,12 @@ if __name__ == "__main__":
     # Load generation model and tokenizer, and prepare sampling params
     logger.info(f"Using {args.model_name} for completion generation")
     model, tokenizer = load_model(
-        args.model_name,
-        args.model_class,
-        args.max_num_gpus,
-        args.num_nodes,
-        args.data_parallel_size,
+        model_name=args.model_name,
+        model_class=args.model_class,
+        max_num_gpus=args.max_num_gpus,
+        num_nodes=args.num_nodes,
+        data_parallel_size=args.data_parallel_size,
+        max_model_len=args.max_model_len,
     )
     sampling_params = vllm.SamplingParams(
         max_tokens=args.max_tokens,

--- a/activeuf/generate_completions.py
+++ b/activeuf/generate_completions.py
@@ -34,6 +34,7 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument("--max_num_gpus", type=int, default=MAX_NUM_GPUS, help="The maximum number of GPUs to use")
     parser.add_argument("--num_nodes", type=int, default=os.getenv("SLURM_NNODES", 1), help="The maximum number of nodes to use for distributed training (if applicable)")
+    parser.add_argument("--data_parallel_size", type=int, default=DATA_PARALLEL_SIZE, help="The size of the data parallel group (only applicable for vllm_server model class)")
     parser.add_argument("--max_tokens", type=int, default=COMPLETION_MAX_TOKENS, help="The maximum number of tokens to generate for each completion")
     parser.add_argument("--temperature", type=int, default=COMPLETION_TEMPERATURE, help="Temperature for generation")
     parser.add_argument("--top_p", type=int, default=COMPLETION_TOP_P, help="top_p value for generation")
@@ -88,7 +89,7 @@ if __name__ == "__main__":
 
     # Load generation model and tokenizer, and prepare sampling params
     logger.info(f"Using {args.model_name} for completion generation")
-    model, tokenizer = load_model(args.model_name, args.model_class, args.max_num_gpus, args.num_nodes)
+    model, tokenizer = load_model(args.model_name, args.model_class, args.max_num_gpus, args.num_nodes, args.data_parallel_size)
     sampling_params = vllm.SamplingParams(
         max_tokens = args.max_tokens,
         temperature = args.temperature,

--- a/activeuf/generate_completions.py
+++ b/activeuf/generate_completions.py
@@ -179,3 +179,9 @@ if __name__ == "__main__":
     args_path = path.join(args.output_path, "args.json")
     with open(args_path, "w") as f_out:
         json.dump(vars(args), f_out)
+
+    # Export first sample
+    first_sample = dataset[0]
+    first_sample_path = path.join(args.output_path, "first_sample.json")
+    with open(first_sample_path, "w") as f_out:
+        json.dump(first_sample, f_out)

--- a/activeuf/oracle/combine_annotated_completions.py
+++ b/activeuf/oracle/combine_annotated_completions.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 from datasets import load_from_disk, Dataset
 from tqdm import tqdm
 
@@ -16,13 +17,14 @@ def combine_annotations(annotations_folder, completions_folder, output_folder):
     datasets_annotation = []
     datasets_completion = []
     foldernames = []
-    for foldername in tqdm(os.listdir(annotations_folder)):
+    for foldername in tqdm(sorted(os.listdir(annotations_folder))):
         dataset = load_from_disk(os.path.join(annotations_folder, foldername))
+        print(f"Loaded annotation dataset from {foldername} with {len(dataset)} entries")
         datasets_annotation.append(dataset)
         foldernames.append(foldername)
 
-    for i, foldername in enumerate(tqdm(os.listdir(completions_folder))):
-        assert foldername == foldernames[i], "Folder ordering does not match"
+    for i, foldername in enumerate(tqdm(sorted(os.listdir(completions_folder)))):
+        assert foldername == foldernames[i], f"Folder ordering does not match got {foldername} expected {foldernames[i]}"
         dataset = load_from_disk(os.path.join(completions_folder, foldername))
         datasets_completion.append(dataset)
 
@@ -72,9 +74,15 @@ def combine_annotations(annotations_folder, completions_folder, output_folder):
 
 
 def main():
-    annotations_folder = "/iopsstor/scratch/cscs/dmelikidze/datasets/ultrafeedback_annotated_combined_new10/"
-    completions_folder = "/iopsstor/scratch/cscs/dmelikidze/datasets/completions_all/"
-    output_folder = "/iopsstor/scratch/cscs/dmelikidze/datasets/combined_annotations_llama/"
+    parser = argparse.ArgumentParser(description="Combine annotated completions datasets.")
+    parser.add_argument("--annotations_folder", type=str, required=True, help="Path to the folder containing annotation datasets.")
+    parser.add_argument("--completions_folder", type=str, required=True, help="Path to the folder containing completion datasets.")
+    parser.add_argument("--output_folder", type=str, required=True, help="Path to save the combined dataset.")
+
+    args = parser.parse_args()
+    annotations_folder = args.annotations_folder
+    completions_folder = args.completions_folder
+    output_folder = args.output_folder
 
     combined_dataset = combine_annotations(
         annotations_folder, completions_folder, output_folder)

--- a/activeuf/oracle/run_annotations.sh
+++ b/activeuf/oracle/run_annotations.sh
@@ -8,6 +8,7 @@ MODELS=(
 "mistralai/Mistral-Small-24B-Instruct-2501"
 "Qwen/Qwen3-30B-A3B"
 "Qwen/Qwen2.5-72B-Instruct"
+"Qwen/Qwen3-235B-A22B"
 "allenai/OLMo-2-0325-32B-Instruct"
 "meta-llama/Llama-3.1-8B-Instruct"
 "google/gemma-3-12b-it"
@@ -16,6 +17,9 @@ MODELS=(
 "nvidia/Llama-3.1-Nemotron-70B-Instruct-HF"
 "Qwen/Qwen3-32B"
 "nvidia/Llama-3_3-Nemotron-Super-49B-v1"
+"nvidia/Llama-3_1-Nemotron-Ultra-253B-v1"
+"deepseek-ai/DeepSeek-V3"
+"allenai/Llama-3.1-Tulu-3-405B"
 )
 
 for MODEL in "${MODELS[@]}"; do
@@ -23,16 +27,17 @@ for MODEL in "${MODELS[@]}"; do
 #!/bin/bash
 #SBATCH --account=a-infra01-1
 #SBATCH --time=06:00:00
-#SBATCH --output=/iopsstor/scratch/cscs/dmelikidze/ActiveUltraFeedback/logs/annotations3/run_%j.out
-#SBATCH --error=/iopsstor/scratch/cscs/dmelikidze/ActiveUltraFeedback/logs/annotations3/run_%j.err
+#SBATCH --output=./logs/annotation/%j.out
 #SBATCH --environment=activeuf_dev
-#SBATCH --job-name=annotations
+#SBATCH --job-name=annotation
+
+export HF_HOME=/iopsstor/scratch/cscs/smarian/hf_cache
 
 python -m activeuf.oracle.get_raw_annotations \
-    --dataset_path /iopsstor/scratch/cscs/dmelikidze/datasets/completions_combined \
-    --model_name="Qwen/Qwen3-32B" \
+    --dataset_path /iopsstor/scratch/cscs/smarian/datasets/2_merged_completions/ultrafeedback \
+    --model_name="meta-llama/Llama-3.3-70B-Instruct" \
     --max_tokens 24000 \
-    --output_path /iopsstor/scratch/cscs/dmelikidze/datasets/ultrafeedback_annotated_combined_new_qwen10/ \
+    --output_path /iopsstor/scratch/cscs/smarian/datasets/3_annotated_completions/ultrafeedback_llama_3.3_70b \
     --model_class vllm \
     --temperature 0.0 \
     --top_p 0.1 \

--- a/activeuf/oracle/run_annotations_multi_node.sh
+++ b/activeuf/oracle/run_annotations_multi_node.sh
@@ -1,0 +1,128 @@
+MODELS=(
+"microsoft/phi-4"
+"meta-llama/Llama-3.3-70B-Instruct"
+"google/gemma-3-27b-it"
+"mistralai/Mistral-Large-Instruct-2411"
+"Qwen/Qwen3-14B"
+"CohereLabs/c4ai-command-a-03-2025"
+"mistralai/Mistral-Small-24B-Instruct-2501"
+"Qwen/Qwen3-30B-A3B"
+"Qwen/Qwen2.5-72B-Instruct"
+"Qwen/Qwen3-235B-A22B"
+"allenai/OLMo-2-0325-32B-Instruct"
+"meta-llama/Llama-3.1-8B-Instruct"
+"google/gemma-3-12b-it"
+"allenai/Llama-3.1-Tulu-3-70B"
+"moonshotai/Moonlight-16B-A3B-Instruct"
+"nvidia/Llama-3.1-Nemotron-70B-Instruct-HF"
+"Qwen/Qwen3-32B"
+"nvidia/Llama-3_3-Nemotron-Super-49B-v1"
+"nvidia/Llama-3_1-Nemotron-Ultra-253B-v1"
+"deepseek-ai/DeepSeek-V3"
+"allenai/Llama-3.1-Tulu-3-405B"
+)
+
+for MODEL in "${MODELS[@]}"; do
+    sbatch <<EOF
+#!/bin/bash
+# shellcheck disable=SC2206
+#SBATCH --account=a-infra01-1
+#SBATCH --exclusive
+#SBATCH --cpus-per-task=288
+#SBATCH --nodes=2
+#SBATCH --gres=gpu:4
+#SBATCH --tasks-per-node=1
+#SBATCH --partition=normal
+#SBATCH --time=12:00:00
+#SBATCH --container-writable
+#SBATCH --job-name=annotation
+#SBATCH --output=./logs/annotation/%j.out
+#SBATCH --environment=activeuf_dev
+# DISABLED SBATCH --exclude=nid006438,nid006439,nid006440,nid006441,nid006442,nid006443,nid006444,nid006445,nid006446,nid006447,nid006448,nid006449,nid006450,nid006451,nid006461,nid006462,nid006868,nid006476,nid005557,nid006455,nid007122,nid007119,nid006513,nid005813,nid006454,nid006452,nid006457,nid005230,nid005248
+
+export RAY_CGRAPH_get_timeout=300
+export VLLM_SERVER_CONCURRENCY_LIMIT=100
+num_nodes_per_instance=2
+
+# Getting the node names and assigning a head node
+nodes=\$(scontrol show hostnames "\$SLURM_JOB_NODELIST")
+nodes_array=(\$nodes)
+
+echo "nodes: \${nodes}"
+echo "nodes_array: \${nodes_array[*]}"
+
+head_node=\${nodes_array[0]}
+head_node_ip=\$(srun --overlap --nodes=1 --ntasks=1 -w "\$head_node" hostname --ip-address)
+
+echo "Head node: \$head_node"
+echo "Head node IP: \$head_node_ip"
+
+export head_node_ip="\$head_node_ip"
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+
+# If we detect a space character in the head node IP, we'll convert it to an ipv4 address. This step is optional.
+if [[ "\$head_node_ip" == *" "* ]]; then
+IFS=' ' read -ra ADDR <<<"\$head_node_ip"
+if [[ \${#ADDR[0]} -gt 16 ]]; then
+  head_node_ip=\${ADDR[1]}
+else
+  head_node_ip=\${ADDR[0]}
+fi
+echo "IPV6 address detected. We split the IPV4 address as \$head_node_ip"
+fi
+
+# Start head node
+port=6382
+head_address=\$head_node_ip:\$port
+export RAY_ADDRESS="\$head_address"
+export VLLM_HOST_IP="\$head_node_ip"
+
+echo "Head Address (set as RAY_ADDRESS): \$head_address"
+echo "Head VLLM_HOST_IP (set for driver): \$VLLM_HOST_IP"
+
+echo "Starting HEAD at \$head_node at IP \$head_node_ip"
+ray start --head \
+          --node-ip-address=\$head_node_ip \
+          --port=\$port \
+          --num-cpus=\${SLURM_CPUS_PER_TASK} \
+          --num-gpus=4  \
+          --resources="{\\"node:\$head_node_ip\\": 1}" \
+          --block & 
+sleep 10  
+
+# Start workers
+worker_num=\$((SLURM_JOB_NUM_NODES - 1))
+for ((i = 1; i <= worker_num; i++)); do
+    node=\${nodes_array[\$i]}
+    node_ip=\$(srun --nodes=1 --overlap --ntasks=1 -w "\$node" hostname --ip-address)
+    echo "Starting WORKER \$i at \$node with IP \$node_ip"
+
+    srun --nodes=1 \
+       --ntasks=1 \
+       --overlap \
+       -w "\$node" \
+       env VLLM_HOST_IP="\$node_ip" CUDA_VISIBLE_DEVICES="0,1,2,3" \
+       ray start --address \$head_address \
+                 --node-ip-address="\$node_ip" \
+                 --num-cpus \${SLURM_CPUS_PER_TASK} \
+                 --num-gpus 4 \
+                 --block &
+    sleep 5
+done
+sleep 10
+
+ray status
+
+python -u -m activeuf.oracle.get_raw_annotations \
+    --dataset_path /iopsstor/scratch/cscs/smarian/datasets/2_merged_completions/ultrafeedback \
+    --model_name="Qwen/Qwen3-235B-A22B" \
+    --max_tokens 24000 \
+    --output_path /iopsstor/scratch/cscs/smarian/datasets/3_annotated_completions/ultrafeedback_qwen_3_235b \
+    --model_class vllm_server \
+    --temperature 0.0 \
+    --top_p 0.1 \
+    --num_nodes \$num_nodes_per_instance \
+    --model_to_annotate "$MODEL" \
+    --batch_size_to_annotate 5000
+EOF
+done

--- a/activeuf/utils.py
+++ b/activeuf/utils.py
@@ -18,7 +18,13 @@ import torch
 
 import openai
 import vllm
-from transformers import pipeline, AutoModelForCausalLM, AutoTokenizer, Pipeline, PreTrainedModel
+from transformers import (
+    pipeline,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    Pipeline,
+    PreTrainedModel,
+)
 
 from activeuf.configs import *
 from activeuf.schemas import *
@@ -83,25 +89,26 @@ def sample_system_prompt(principle: str) -> str:
 
 
 def load_model(
-        model_name: str,
-        model_class: str = DEFAULT_MODEL_CLASS,
-        max_num_gpus: int | None = None,
-        num_nodes: int = 1,
-        ping_delay: int = PING_DELAY,
-        max_ping_retries: int = MAX_PING_RETRIES,
-        model_kwargs: dict = {},
-    ) -> Union[
-        # model requires API calls (e.g. gpt-4) or model_class == "vllm_server"
-        tuple[str, None],
-        # model_class == "transformers"
-        tuple[AutoModelForCausalLM, AutoTokenizer],
-        # model_class == "pipeline"
-        tuple[Pipeline, None],
-        # model_class == "vllm"
-        tuple[vllm.LLM, vllm.transformers_utils.tokenizer.AnyTokenizer],
+    model_name: str,
+    model_class: str = DEFAULT_MODEL_CLASS,
+    max_num_gpus: int | None = None,
+    num_nodes: int = 1,
+    data_parallel_size: int = 1,
+    ping_delay: int = PING_DELAY,
+    max_ping_retries: int = MAX_PING_RETRIES,
+    model_kwargs: dict = {},
+) -> Union[
+    # model requires API calls (e.g. gpt-4) or model_class == "vllm_server"
+    tuple[str, None],
+    # model_class == "transformers"
+    tuple[AutoModelForCausalLM, AutoTokenizer],
+    # model_class == "pipeline"
+    tuple[Pipeline, None],
+    # model_class == "vllm"
+    tuple[vllm.LLM, vllm.transformers_utils.tokenizer.AnyTokenizer],
 ]:
     """
-    Loads a model given the name. 
+    Loads a model given the name.
 
     If the specified model is among the supported APIs, no model is actually loaded and the model name is returned.
 
@@ -110,9 +117,10 @@ def load_model(
         model_class (Optional[str]): The class of the model to load. This determines the type of the output. Must be one of ["transformers", "pipeline", "vllm", "vllm_server"].
         max_num_gpus (Optional[int]): The maximum number of GPUs to use for loading the model (only used for vLLM models).
         num_nodes (int): The number of nodes to use for loading the model. This is only used for vLLM models.
+        data_parallel_size (Optional[int]): The size of the data parallel group (only applicable for vllm_server model class).
         ping_delay (int): Delay between pings to the vLLM server to check if it is already running (only used for model_class == "vllm_server").
         max_ping_retries (int): Number of retries to check if the vLLM server is running (only used for model_class == "vllm_server").
-        model_kwargs (Optional[dict]): Additional keyword arguments to pass to the model when loading it. 
+        model_kwargs (Optional[dict]): Additional keyword arguments to pass to the model when loading it.
     Returns:
         Union[Tuple[str, None], Tuple[AutoModelForCausalLM, AutoTokenizer], Tuple[Pipeline, None], Tuple[LLM, vllm.transformers_utils.tokenizer.AnyTokenizer]]: The loaded model and tokenizer (if applicable).
     """
@@ -133,13 +141,10 @@ def load_model(
             # torch_dtype="auto",
             # * Avoid sliding window attention warning (this warning only occurs for Qwen2.5 models. But the code on the model card also does not do this)
             # attn_implementation="flash_attention_2",
-            **model_kwargs
+            **model_kwargs,
         )
         # padding_side should be "left" for text generation (https://huggingface.co/docs/transformers/llm_tutorial)
-        tokenizer = AutoTokenizer.from_pretrained(
-            model_name,
-            padding_side="left"
-        )
+        tokenizer = AutoTokenizer.from_pretrained(model_name, padding_side="left")
     elif model_class == "vllm":
         # Search over tensor_parallel_size, as number of attention heads needs to be divisible by it
         tps = tensor_parallel_size
@@ -155,25 +160,22 @@ def load_model(
                     "trust_remote_code": True,
                     "dtype": "auto",
                     "download_dir": os.getenv("HF_CACHE", None),
-                    **model_kwargs
+                    **model_kwargs,
                 }
 
                 # Specify tokenizer mode for Mistral models
                 if "mistral" in model_name.lower():
                     vllm_kwargs["tokenizer_mode"] = "mistral"
 
-                model = vllm.LLM(
-                    model_name,
-                    **vllm_kwargs
-                )
+                model = vllm.LLM(model_name, **vllm_kwargs)
             except Exception as e:
-                print(
-                    f"Failed to load model with tensor_parallel_size={tps}: {e}")
-                print(f"Retrying with tensor_parallel_size={tps-1}...")
+                print(f"Failed to load model with tensor_parallel_size={tps}: {e}")
+                print(f"Retrying with tensor_parallel_size={tps - 1}...")
                 tps -= 1
         if model is None:
             raise ValueError(
-                f"Failed to load model {model_name} with any tensor_parallel_size.")
+                f"Failed to load model {model_name} with any tensor_parallel_size."
+            )
 
         tokenizer = model.get_tokenizer()
     elif model_class == "vllm_server":
@@ -184,24 +186,36 @@ def load_model(
         while model is None and tps > 0:
             try:
                 out_file = f"./logs/server/{model_name.split('/')[-1]}_server_tps_{tps}"
-                out_file += f"_{os.getenv('SLURM_JOB_ID', '')}.out" if os.getenv(
-                    "SLURM_JOB_ID", None) else ".out"
+                out_file += (
+                    f"_{os.getenv('SLURM_JOB_ID', '')}.out"
+                    if os.getenv("SLURM_JOB_ID", None)
+                    else ".out"
+                )
 
                 command = f"vllm serve {model_name}"
                 command += " --gpu-memory-utilization 0.9"
                 command += " --swap-space 1"
                 command += f" --tensor-parallel-size {tps}"
                 command += f" --pipeline-parallel-size {num_nodes}"
+                command += f" --data-parallel-size {data_parallel_size}"
                 command += " --trust-remote-code"
                 command += " --dtype auto"
-                command += f" --download-dir {os.getenv('HF_CACHE', None)}" if os.getenv(
-                    "HF_CACHE", None) else ""
+                command += (
+                    f" --download-dir {os.getenv('HF_CACHE', None)}"
+                    if os.getenv("HF_CACHE", None)
+                    else ""
+                )
                 command += f" --port 8000"  # Default port
-                command += " --tokenizer-mode=mistral" if "mistral" in model_name.lower() else ""
+                command += (
+                    " --tokenizer-mode=mistral"
+                    if "mistral" in model_name.lower()
+                    else ""
+                )
                 command += f" > {out_file} 2>&1"
                 command += " &"  # Run in background
 
                 os.system(command)
+                print(f"Starting vLLM server with command: {command}")
                 print(f"Logging server output to {out_file}")
 
                 server_ready = False
@@ -212,46 +226,49 @@ def load_model(
                             server_ready = True
                             break
                     except Exception as e:
-                        print(f"Ping attempt {attempt+1} failed: {e}")
+                        print(f"Ping attempt {attempt + 1} failed: {e}")
                     time.sleep(ping_delay)
 
                 if not server_ready:
                     raise RuntimeError(
-                        "vLLM server did not start after maximum retries.")
+                        "vLLM server did not start after maximum retries."
+                    )
                 else:
                     print("vLLM server is ready.")
 
                 model = "http://localhost:8000"  # Return the URL of the vLLM server
-                tokenizer = None                 # No tokenizer needed for vLLM server API calls
+                tokenizer = None  # No tokenizer needed for vLLM server API calls
 
             except Exception as e:
-                print(
-                    f"Failed to load model with tensor_parallel_size={tps}: {e}")
-                print(f"Retrying with tensor_parallel_size={tps-1}...")
+                print(f"Failed to load model with tensor_parallel_size={tps}: {e}")
+                print(f"Retrying with tensor_parallel_size={tps - 1}...")
                 tps -= 1
 
         if model is None:
             raise ValueError(
-                f"Failed to load model {model_name} with any tensor_parallel_size.")
+                f"Failed to load model {model_name} with any tensor_parallel_size."
+            )
     elif model_class == "pipeline":
         model = pipeline(
             "text-generation",
             model=model_name,
             torch_dtype="auto",
             device_map="auto",
-            **model_kwargs
+            **model_kwargs,
         )
         tokenizer = None
     else:
         raise ValueError(
-            f"Invalid model_class: {model_class}. Must be one of ['transformers', 'pipeline', 'vllm']")
+            f"Invalid model_class: {model_class}. Must be one of ['transformers', 'pipeline', 'vllm']"
+        )
 
     # Check tokenizer and set padding token if needed
     if tokenizer is not None:
-        if not 'mistral' in model_name.lower() and tokenizer.chat_template is None:
+        if not "mistral" in model_name.lower() and tokenizer.chat_template is None:
             raise ValueError(
-                "Tokenizer does not have a chat template. Please use a model that supports chat templates.")
-        if not 'mistral' in model_name.lower() and tokenizer.pad_token is None:
+                "Tokenizer does not have a chat template. Please use a model that supports chat templates."
+            )
+        if not "mistral" in model_name.lower() and tokenizer.pad_token is None:
             tokenizer.pad_token = tokenizer.eos_token
 
             if isinstance(model, PreTrainedModel):
@@ -260,7 +277,13 @@ def load_model(
     return model, tokenizer
 
 
-async def vllm_server_inference(url: str, all_messages: list[list[dict[str, str]]], sampling_params: vllm.SamplingParams, max_api_retry: int, generate_kwargs: dict) -> list[str]:
+async def vllm_server_inference(
+    url: str,
+    all_messages: list[list[dict[str, str]]],
+    sampling_params: vllm.SamplingParams,
+    max_api_retry: int,
+    generate_kwargs: dict,
+) -> list[str]:
     """
     Helper function to perform asynchronous inference using a vLLM server.
 
@@ -277,23 +300,26 @@ async def vllm_server_inference(url: str, all_messages: list[list[dict[str, str]
     client = openai.AsyncOpenAI(
         api_key="EMPTY",
         base_url=f"{url}/v1",
-        http_client=httpx.AsyncClient(
-            verify=False, timeout=httpx.Timeout(None))
+        http_client=httpx.AsyncClient(verify=False, timeout=httpx.Timeout(None)),
     )
 
     models = await client.models.list()
     model = models.data[0].id
 
-    # Use a semaphore to limit the number of concurrent requests
-    concurrency_limit = 50
+    concurrency_limit = int(os.getenv("VLLM_SERVER_CONCURRENCY_LIMIT", 50))
     semaphore = asyncio.Semaphore(concurrency_limit)
+
+    print(
+        f"Using vLLM server at {url} with model {model}. Concurrency limit: {concurrency_limit}"
+    )
 
     # Define helper function that runs the API calls asynchronously
     async def send_request(conversation):
         async with semaphore:
             for _ in range(max_api_retry):
                 try:
-                    return await client.chat.completions.create(
+                    start = time.time()
+                    response = await client.chat.completions.create(
                         model=model,
                         messages=conversation,
                         temperature=sampling_params.temperature,
@@ -302,11 +328,15 @@ async def vllm_server_inference(url: str, all_messages: list[list[dict[str, str]
                         presence_penalty=sampling_params.presence_penalty,
                         frequency_penalty=sampling_params.frequency_penalty,
                     )
+                    end = time.time()
+                    print(
+                        f"Completion successfuly generated in {end - start:.2f} seconds."
+                    )
+                    return response
                 except Exception as e:
                     print(f"An error occurred: {e}. Retrying...")
                     await asyncio.sleep(1)
-            raise RuntimeError(
-                f"Failed to get response after {max_api_retry} retries.")
+            raise RuntimeError(f"Failed to get response after {max_api_retry} retries.")
 
     tasks = [send_request(chat) for chat in all_messages]
     responses = await async_tqdm.gather(*tasks)
@@ -356,7 +386,7 @@ def get_response_texts(
                             top_p=sampling_params.top_p,
                             presence_penalty=sampling_params.presence_penalty,
                             frequency_penalty=sampling_params.frequency_penalty,
-                            **generate_kwargs
+                            **generate_kwargs,
                         )
                     except Exception as e:
                         print(e)
@@ -365,30 +395,31 @@ def get_response_texts(
                         responses.append(response)
                         break
             response_texts = [
-                response.choices[0].message.content for response in responses]
+                response.choices[0].message.content for response in responses
+            ]
         else:
             response_texts, responses = asyncio.run(
                 vllm_server_inference(
-                    model,
-                    all_messages,
-                    sampling_params,
-                    max_api_retry,
-                    generate_kwargs
+                    model, all_messages, sampling_params, max_api_retry, generate_kwargs
                 )
             )
 
     elif isinstance(model, PreTrainedModel):
         if tokenizer is None:
             raise ValueError(
-                "Tokenizer must be provided if model is an AutoModelForCausalLM (PreTrainedModel).")
+                "Tokenizer must be provided if model is an AutoModelForCausalLM (PreTrainedModel)."
+            )
 
         # ensure padding_side "left" (https://huggingface.co/docs/transformers/llm_tutorial)
         if tokenizer.padding_side != "left":
             raise ValueError(
-                "Tokenizer padding side must be 'left' for text generation.")
+                "Tokenizer padding side must be 'left' for text generation."
+            )
 
-        batches = [all_messages[i:i + batch_size]
-                   for i in range(0, len(all_messages), batch_size)]
+        batches = [
+            all_messages[i : i + batch_size]
+            for i in range(0, len(all_messages), batch_size)
+        ]
         response_texts = []
         responses = []
 
@@ -415,9 +446,10 @@ def get_response_texts(
             )
 
             # AutoModelForCausalLM does not allow to return only the generated text so manually remove the input
-            batch_outputs = batch_outputs[:, batch_inputs.input_ids.shape[1]:]
+            batch_outputs = batch_outputs[:, batch_inputs.input_ids.shape[1] :]
             batch_texts = tokenizer.batch_decode(
-                batch_outputs, skip_special_tokens=True)
+                batch_outputs, skip_special_tokens=True
+            )
 
             response_texts.extend(batch_texts)
             responses.extend(batch_outputs)
@@ -432,24 +464,27 @@ def get_response_texts(
                 # use_tqdm=False, # to avoid spamming the console with progress bars
                 # disable thinking for now
                 chat_template_kwargs={"enable_thinking": False},
-                **generate_kwargs
+                **generate_kwargs,
             )
         except Exception as e:
             print(
-                f"Failed to generate responses with vLLM: {e}\nRetrying without fixed chat template...")
+                f"Failed to generate responses with vLLM: {e}\nRetrying without fixed chat template..."
+            )
             responses = model.chat(
                 all_messages,
                 sampling_params=sampling_params,
                 # use_tqdm=False, # to avoid spamming the console with progress bars
                 # disable thinking for now
                 chat_template_kwargs={"enable_thinking": False},
-                **generate_kwargs
+                **generate_kwargs,
             )
         response_texts = [_.outputs[0].text for _ in responses]
 
     elif isinstance(model, Pipeline):
-        batches = [all_messages[i:i + batch_size]
-                   for i in range(0, len(all_messages), batch_size)]
+        batches = [
+            all_messages[i : i + batch_size]
+            for i in range(0, len(all_messages), batch_size)
+        ]
         responses = []
 
         for batch in tqdm(batches, desc="Generating responses", total=len(batches)):
@@ -460,15 +495,15 @@ def get_response_texts(
                 temperature=sampling_params.temperature,
                 top_p=sampling_params.top_p,
                 max_new_tokens=sampling_params.max_tokens,
-                **generate_kwargs
+                **generate_kwargs,
             )
 
             responses.extend(batch_outputs)
-        response_texts = [response[0]["generated_text"]
-                          for response in responses]
+        response_texts = [response[0]["generated_text"] for response in responses]
     else:
         raise ValueError(
-            f"Was not able to resolve model to be used for generation. model: {model}")
+            f"Was not able to resolve model to be used for generation. model: {model}"
+        )
 
     return response_texts, responses
 

--- a/activeuf/utils.py
+++ b/activeuf/utils.py
@@ -355,6 +355,9 @@ async def vllm_server_inference(
                         frequency_penalty=sampling_params.frequency_penalty,
                         logprobs=True if sampling_params.logprobs else False,
                         top_logprobs=sampling_params.logprobs,
+                        extra_body={
+                            "chat_template_kwargs": {"enable_thinking": False},
+                        },
                     )
                     return response
                 except Exception as e:

--- a/activeuf/utils.py
+++ b/activeuf/utils.py
@@ -318,7 +318,6 @@ async def vllm_server_inference(
         async with semaphore:
             for _ in range(max_api_retry):
                 try:
-                    start = time.time()
                     response = await client.chat.completions.create(
                         model=model,
                         messages=conversation,
@@ -327,10 +326,8 @@ async def vllm_server_inference(
                         top_p=sampling_params.top_p,
                         presence_penalty=sampling_params.presence_penalty,
                         frequency_penalty=sampling_params.frequency_penalty,
-                    )
-                    end = time.time()
-                    print(
-                        f"Completion successfuly generated in {end - start:.2f} seconds."
+                        logprobs=True if sampling_params.logprobs else False,
+                        top_logprobs=sampling_params.logprobs,
                     )
                     return response
                 except Exception as e:
@@ -386,6 +383,8 @@ def get_response_texts(
                             top_p=sampling_params.top_p,
                             presence_penalty=sampling_params.presence_penalty,
                             frequency_penalty=sampling_params.frequency_penalty,
+                            logprobs=True if sampling_params.logprobs else False,
+                            top_logprobs=sampling_params.logprobs,
                             **generate_kwargs,
                         )
                     except Exception as e:

--- a/activeuf/utils.py
+++ b/activeuf/utils.py
@@ -232,7 +232,13 @@ def load_model(
                 command += f" --pipeline-parallel-size {num_nodes}"
                 command += f" --data-parallel-size {data_parallel_size}"
                 command += " --trust-remote-code"
-                command += " --dtype auto"
+                command += (
+                    " --dtype auto"
+                    if "deepseek" in model_name.lower()
+                    else " --dtype bfloat16"
+                )
+                command += " --port 8000"  # Default port
+
                 command += (
                     f" --max-model-len {max_model_len}" if max_model_len > 0 else ""
                 )

--- a/activeuf/utils.py
+++ b/activeuf/utils.py
@@ -96,6 +96,7 @@ def load_model(
     data_parallel_size: int = 1,
     ping_delay: int = PING_DELAY,
     max_ping_retries: int = MAX_PING_RETRIES,
+    gpu_memory_utilization: float = 0.9,
     max_model_len: int = 0,
     model_kwargs: dict = {},
 ) -> Union[
@@ -121,6 +122,7 @@ def load_model(
         data_parallel_size (Optional[int]): The size of the data parallel group (only applicable for vllm_server model class).
         ping_delay (int): Delay between pings to the vLLM server to check if it is already running (only used for model_class == "vllm_server").
         max_ping_retries (int): Number of retries to check if the vLLM server is running (only used for model_class == "vllm_server").
+        gpu_memory_utilization (float): The GPU memory utilization to use for loading the model (only used for vllm models).
         max_model_len (int): The maximum context length of the model. Pass 0 to use the model's default max length.
         model_kwargs (Optional[dict]): Additional keyword arguments to pass to the model when loading it.
     Returns:
@@ -155,7 +157,7 @@ def load_model(
         while model is None and tps > 0:
             try:
                 vllm_kwargs = {
-                    "gpu_memory_utilization": 0.9,
+                    "gpu_memory_utilization": gpu_memory_utilization,
                     "swap_space": 1,
                     "tensor_parallel_size": tps,
                     "pipeline_parallel_size": num_nodes,
@@ -224,7 +226,7 @@ def load_model(
                 out_file += f"tp_{tps}_pp_{num_nodes}_dp_{data_parallel_size}.out"
 
                 command = f"vllm serve {model_name}"
-                command += " --gpu-memory-utilization 0.9"
+                command += f" --gpu-memory-utilization {gpu_memory_utilization}"
                 command += " --swap-space 1"
                 command += f" --tensor-parallel-size {tps}"
                 command += f" --pipeline-parallel-size {num_nodes}"

--- a/activeuf/utils.py
+++ b/activeuf/utils.py
@@ -183,6 +183,22 @@ def load_model(
         tps = tensor_parallel_size
         model = None
 
+        # Check if vLLM server is already running
+        server_url = "http://localhost:8000/ping"
+        server_running = False
+        try:
+            response = requests.get(server_url)
+            if response.status_code == 200:
+                print("vLLM server is already running.")
+                model = "http://localhost:8000"
+                tokenizer = None
+                server_running = True
+        except Exception:
+            pass
+
+        if server_running:
+            tps = 0  # Skip starting a new server
+
         while model is None and tps > 0:
             try:
                 out_dir = f"./logs/server/{model_name.split('/')[-1]}"

--- a/activeuf/utils.py
+++ b/activeuf/utils.py
@@ -74,12 +74,12 @@ def set_seed(seed: int) -> None:
 
 
 def sample_principle(source: str) -> str:
-    principle_pool = PROMPT_SOURCE2PRINCIPLES.get(source, [DEFAULT_PRINCIPLE])
+    principle_pool = PROMPT_SOURCE2PRINCIPLES.get(source, DEFAULT_PRINCIPLES)
     principle = random.choice(principle_pool)
 
-    if principle == "honesty":
-        if "verbalized_calibration" in PRINCIPLES and np.random.rand() < 0.9:
-            principle = "verbalized_calibration"
+    # if principle == "honesty":
+    #     if "verbalized_calibration" in PRINCIPLES and np.random.rand() < 0.9:
+    #         principle = "verbalized_calibration"
 
     return principle
 

--- a/scripts/eval_judge_rewardbench.py
+++ b/scripts/eval_judge_rewardbench.py
@@ -1,0 +1,497 @@
+"""
+This script is used to annotate the completions generated from the generate_completions.py script.
+It uses a LLM as a judge to rate the completions based on the aspects defined in the configs.py file and provides critique/feedback for each completion.
+
+Adapted from https://github.com/allenai/reward-bench/blob/main/scripts/run_v2.py
+
+Example run command:
+python -m scripts.eval_judge_rewardbench \
+    --model_path="Qwen/Qwen3-32B" \
+    --output_path /iopsstor/scratch/cscs/smarian/data/judge_rewardbench/Qwen3-32B \
+    --max_tokens 24000 \
+    --model_class vllm \
+    --temperature 0.0 \
+    --top_p 0.1
+
+python -m scripts.eval_judge_rewardbench \
+    --model_path="meta-llama/Llama-3.3-70B-Instruct" \
+    --output_path /iopsstor/scratch/cscs/smarian/data/judge_rewardbench/Llama-3.3-70B-Instruct \
+    --max_tokens 24000 \
+    --model_class vllm \
+    --temperature 0.0 \
+    --top_p 0.1
+"""
+
+import argparse
+import json
+import os
+import numpy as np
+import pandas as pd
+from typing import Dict
+from collections import defaultdict
+
+
+import torch
+from vllm import SamplingParams, LLM
+from datasets import Dataset, load_from_disk, load_dataset
+
+from activeuf.configs import *
+from activeuf.schemas import *
+from activeuf.utils import *
+from activeuf.oracle.prompts import *
+
+ASPECT2ANNOTATION_PROMPT = {
+    "instruction_following": INSTRUCTION_FOLLOWING_ANNOTATION_SYSTEM_PROMPT,
+    "honesty": HONESTY_ANNOTATION_SYSTEM_PROMPT,
+    "truthfulness": TRUTHFULNESS_ANNOTATION_SYSTEM_PROMPT,
+    "helpfulness": HELPFULNESS_ANNOTATION_SYSTEM_PROMPT,
+}
+
+logger = get_logger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    # fmt: off
+
+    # Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output_path", type=str, help="Where to export the results and annotated dataset")
+    parser.add_argument("--model_path", type=str, required=True, help="The (Huggingface) to the model to use for annotation")
+    parser.add_argument("--seed", type=int, default=SEED, help="Seed for random sampling")
+
+    parser.add_argument("--model_class", type=str, default=DEFAULT_MODEL_CLASS, help="The class which is used to perform inference (e.g. transformers, pipeline, vllm)")
+    parser.add_argument("--max_tokens", type=int, default=ANNOTATION_MAX_TOKENS, help="The maximum number of tokens for LLM responses")
+    parser.add_argument("--max_num_gpus", type=int, default=MAX_NUM_GPUS, help="The maximum number of GPUs to use")
+    parser.add_argument("--temperature", type=float, default=ANNOTATION_TEMPERATURE, help="The temperature for sampling")
+    parser.add_argument("--top_p", type=float, default=ANNOTATION_TOP_P, help="The top_p for sampling")
+
+    parser.add_argument("--debug", action="store_true", help="If set, will only annotate the first few samples")
+
+    args = parser.parse_args()
+
+    return args
+
+
+def calculate_probabilities(raw_output, tokenizer, target_words):
+    target_token_ids = [
+        tokenizer.encode(t, add_special_tokens=False)[0] for t in target_words
+    ]
+
+    word_probabilities = []
+
+    for output in raw_output:
+        logprobs = output.outputs[0].logprobs
+
+        logprob_dict = logprobs[0]
+
+        token_logprobs = {}
+        for t, tid in zip(target_words, target_token_ids):
+            token_logprobs[t] = logprob_dict.get(tid, -float("inf"))
+
+        def get_logprob_value(lp):
+            return lp.logprob if hasattr(lp, "logprob") else lp
+
+        exp_values = [np.exp(get_logprob_value(lp)) for lp in token_logprobs.values()]
+
+        total = sum(exp_values)
+        prob_dict = {
+            k: float(v) / total for k, v in zip(token_logprobs.keys(), exp_values)
+        }
+
+        word_probabilities.append(prob_dict)
+
+    return word_probabilities
+
+
+def probabilities_to_score(probabilities: Dict[str, float]) -> float:
+    expectation = 0
+    for rating in range(1, 6):
+        expectation += rating * probabilities.get(str(rating))
+    return expectation
+
+
+def grouped_probabilities_to_score(
+    grouped_probabilities: List[Dict[str, float]],
+) -> float:
+    return sum(probabilities_to_score(prob) for prob in grouped_probabilities) / len(
+        grouped_probabilities
+    )
+
+
+def reroll_and_score_dataset(
+    dataset, total_completions, cols_to_combine=["text", "scores"]
+):
+    """
+    Taken from rewardbench repo: https://github.com/allenai/reward-bench/blob/a0096928eb1d54edd3f6361374708cc68e738b79/rewardbench/utils.py#L535
+    """
+    # Convert to pandas DataFrame for easier manipulation
+    df = dataset.to_pandas()
+
+    # Validate that sum of total_completions matches dataset length
+    if sum(total_completions) != len(df):
+        raise ValueError(
+            f"Sum of total_completions ({sum(total_completions)}) does not equal dataset length ({len(df)})"
+        )
+
+    rerolled_rows = []
+    current_idx = 0
+
+    # Process each group with its specified number of completions
+    for group_size in total_completions:
+        group = df.iloc[current_idx : current_idx + group_size]
+
+        # Create new row
+        new_row = {}
+        # print(group['scores'])
+        # Handle text and score columns - combine into lists
+        for col in cols_to_combine:
+            new_row[col] = group[col].tolist()
+
+        # penalty for ties
+        scores = new_row["scores"]
+        max_val = np.max(scores)
+        new_row["results"] = (
+            (1 / np.sum(scores == max_val)) if scores[0] == max_val else 0
+        )
+
+        # new_row["results"] = 1 if np.argmax(new_row["scores"]) == 0 else 0
+
+        # Handle all other columns - verify they're identical and take first value
+        other_columns = [col for col in df.columns if col not in cols_to_combine]
+        for col in other_columns:
+            values = group[col].unique()
+            if len(values) != 1:
+                raise ValueError(
+                    f"Column {col} has different values within group at index {current_idx}: {values}"
+                )
+            new_row[col] = values[0]
+
+        rerolled_rows.append(new_row)
+        current_idx += group_size
+
+    # Create new dataset
+    rerolled_df = pd.DataFrame(rerolled_rows)
+    rerolled_dataset = Dataset.from_pandas(rerolled_df)
+
+    return rerolled_dataset
+
+
+def check_tokenizer_chat_template(tokenizer):
+    """
+    Check if tokenizer has non none chat_template attribute.
+    """
+    if hasattr(tokenizer, "chat_template"):
+        if tokenizer.chat_template is not None:
+            return True
+    return False
+
+
+# Helper function for scoring ties subset
+def _compute_prompt_stats(
+    samples: List[Tuple[bool, float]],
+) -> Tuple[bool, float | None, float | None]:
+    """
+    Given a list of (is_correct, score) tuples for one prompt,
+    return:
+        accurate ................ True if every correct answer outscores the best wrong one
+        different_correct_margin  Spread between best and worst correct answers (None if <2)
+        correct_incorrect_margin  Gap between worst correct and best wrong (None if N/A)
+    """
+    correct_scores = [s for is_corr, s in samples if is_corr]
+    incorrect_scores = [s for is_corr, s in samples if not is_corr]
+    best_correct = max(correct_scores)
+    worst_correct = min(correct_scores)
+    best_incorrect = max(incorrect_scores)
+
+    # Calculate the margins with correct scores, and also the margin between correct and incorrect scores
+    different_correct_margin = (
+        best_correct - worst_correct if len(correct_scores) > 1 else None
+    )
+    correct_incorrect_margin = worst_correct - best_incorrect
+    accurate = correct_incorrect_margin > 0
+
+    return accurate, different_correct_margin, correct_incorrect_margin
+
+
+def process_single_model(dataset):
+    """
+    Process a single-model ties evaluation dataset and return
+        (dataset_with_results_column, overall_score)
+    Each row in the dataset contains a list of "scores", where the first "num_correct" correspond to
+        correct answers, and the rest are incorrect. The "id" field is formatted as "sample_type:prompt_id",
+        where sample_type is either "ref" for reference prompts with 1 correct answer or "tied" for tied samples
+        with multiple correct answers.
+    Overall score is essentially 60% accuracy, 40% margin. Accuracy is broken down equally
+        across ref and tied accuracy, while margin is broken down into whether the margin between
+        correct answers < margin between correct and incorrect answers for tied prompts only (correctness_preferred)
+        and whether this margin also holds when the margin between correct and incorrect answers is the min of the
+        margin for a tied prompt and its associated reference prompt (correctness_preferred_hard).
+    """
+    grouped_samples: Dict[Tuple[str, int], List[Tuple[bool, float]]] = defaultdict(list)
+
+    for sample in dataset:
+        # Split samples into ref and tied
+        sample_type, prompt_id_str = sample["id"].split(":")
+        prompt_id = int(prompt_id_str)
+
+        # Each score position i is “correct” if i < num_correct
+        for i, raw_score in enumerate(sample["scores"]):
+            score = raw_score[0] if isinstance(raw_score, list) else raw_score
+            grouped_samples[(sample_type, prompt_id)].append(
+                (i < sample["num_correct"], score)
+            )
+
+    # Calculate per-prompt stats
+    ref_stats = {}
+    tied_stats = {}
+
+    for (sample_type, prompt_id), samples in grouped_samples.items():
+        stats = _compute_prompt_stats(samples)
+        if sample_type == "ref":
+            ref_stats[prompt_id] = stats
+        else:  # "tied"
+            tied_stats[prompt_id] = stats
+
+    # Calculate global metrics
+    # Average accuracy (element 0 of each tuple) over ref and tied samples
+    ref_accuracy = np.mean([s[0] for s in ref_stats.values()]) if ref_stats else 0.0
+    tied_accuracy = np.mean([s[0] for s in tied_stats.values()]) if tied_stats else 0.0
+
+    # Margins: compute whether margin within correct answers < margin between correct and incorrect answers
+    all_prompts = set(ref_stats) & set(tied_stats)
+
+    # correct margin is element 1 in stats tuple, correct-incorrect margin is element 2
+    diff_corr_margin = np.array([tied_stats[pid][1] for pid in all_prompts])
+    corr_incorrect_ties = np.array([tied_stats[pid][2] for pid in all_prompts])
+    corr_incorrect_ref = np.array([ref_stats[pid][2] for pid in all_prompts])
+
+    correctness_preferred = np.mean(corr_incorrect_ties > diff_corr_margin)
+    correctness_preferred_hard = np.mean(
+        np.minimum(corr_incorrect_ref, corr_incorrect_ties) > diff_corr_margin
+    )
+
+    # Tie-breaking term, optional, not much effect in practice
+    # Normalised gap, then tanh to keep it in (‑1, 1)
+    margin_scores = np.tanh(
+        np.minimum(corr_incorrect_ref, corr_incorrect_ties) / diff_corr_margin - 1
+    )
+    # if nan (divide by 0), set to 0
+    margin_scores = np.nan_to_num(margin_scores, nan=0.0)
+    correctness_margin_score = float(np.mean(margin_scores))
+
+    # Compute the overall score
+    overall_score = (
+        0.30 * tied_accuracy
+        + 0.30 * ref_accuracy
+        + 0.20 * correctness_preferred
+        + 0.20 * correctness_preferred_hard
+        + 0.01 * correctness_margin_score
+    )
+
+    # Package results — there is less of a sense of per-prompt results for the Ties subset,
+    # as overall_score is computed across the subset, so set "results" to None for clarity
+    if "results" in dataset.column_names:
+        dataset = dataset.remove_columns(["results"])
+    results_dataset = dataset.add_column("results", [None] * len(dataset))
+
+    return results_dataset, float(overall_score)
+
+
+def run(dataset: Dataset, args: argparse.Namespace):
+    chosen_scores = [[] for _ in range(len(dataset))]
+    chosen_probabilities = [[] for _ in range(len(dataset))]
+    rejected_scores = [[] for _ in range(len(dataset))]
+    rejected_probabilities = [[] for _ in range(len(dataset))]
+
+    logger.info("Unrolling dataset for annotation")
+    unrolled_dataset = []
+    subsets = []
+    total_completions = []
+    num_correct = []
+    ids = []
+    text = []  # Is also tokenized in actual rewardbench code but not necessary here
+    for i, sample in enumerate(dataset):
+        total_completions.append(sample["total_completions"])
+        num_correct.append(sample["num_correct"])
+        for chosen_completion in sample["chosen"]:
+            unrolled_dataset.append(
+                {
+                    "id": sample["id"],
+                    "row": i,
+                    "type": "chosen",
+                    "prompt": sample["prompt"],
+                    "completion": chosen_completion,
+                }
+            )
+            subsets.append(sample["subset"])
+            ids.append(sample["id"])
+            text.append(sample["prompt"] + "\n" + chosen_completion)
+        for rejected_completion in sample["rejected"]:
+            unrolled_dataset.append(
+                {
+                    "id": sample["id"],
+                    "row": i,
+                    "type": "rejected",
+                    "prompt": sample["prompt"],
+                    "completion": rejected_completion,
+                }
+            )
+            subsets.append(sample["subset"])
+            ids.append(sample["id"])
+            text.append(sample["prompt"] + "\n" + rejected_completion)
+
+    logger.info("Creating messages")
+    conversations = []
+    for sample in unrolled_dataset:
+        for _, annotation_prompt in ASPECT2ANNOTATION_PROMPT.items():
+            conversations.append(
+                [
+                    {
+                        "role": "system",
+                        "content": PREFERENCE_ANNOTATION_SYSTEM_PROMPT,
+                    },
+                    {
+                        "role": "user",
+                        "content": annotation_prompt.format(
+                            prompt=sample["prompt"],
+                            completion=sample["completion"],
+                        ),
+                    },
+                ]
+            )
+
+    # print("len(subsets)", len(subsets))
+    # print("subsets[0]", subsets[0])
+    # print("len(total_completions)", len(total_completions))
+    # print("total_completions[0]", total_completions[0])
+    # print("len(num_correct)", len(num_correct))
+    # print("num_correct[0]", num_correct[0])
+    # print("len(unrolled_dataset)", len(unrolled_dataset))
+    # print("len(ids)", len(ids))
+    # print("ids[0]", ids[0])
+    # print("len(conversations)", len(conversations))
+
+    logger.info(f"Loading {args.model_path} for annotation")
+    model, tokenizer = load_model(
+        args.model_path, args.model_class, max_num_gpus=torch.cuda.device_count()
+    )
+
+    logger.info("Running inference for annotation")
+    sampling_params = SamplingParams(
+        max_tokens=64,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        logprobs=20,
+    )
+
+    _, response_objects = get_response_texts(
+        model, tokenizer, conversations, sampling_params
+    )
+
+    logger.info("Extracting probabilities from completions")
+    probabilities = calculate_probabilities(
+        response_objects, tokenizer, target_words=["1", "2", "3", "4", "5"]
+    )
+
+    logger.info("Grouping probabilities by completion")
+    n_aspects = len(ASPECT2ANNOTATION_PROMPT)
+    grouped_probabilities = [
+        probabilities[i : i + n_aspects]
+        for i in range(0, len(probabilities), n_aspects)
+    ]
+
+    logger.info("Calculating scores for each completion")
+    scores = [grouped_probabilities_to_score(probs) for probs in grouped_probabilities]
+
+    assert len(scores) == len(unrolled_dataset)
+
+    # Create a new dataset with only the 'id' column
+    out_dataset = Dataset.from_dict({"text": text})
+    out_dataset = out_dataset.add_column("subset", subsets)
+    out_dataset = out_dataset.add_column("id", ids)
+    out_dataset = out_dataset.add_column("scores", scores)
+
+    out_dataset = reroll_and_score_dataset(
+        out_dataset, total_completions, cols_to_combine=["text", "scores"]
+    )
+    out_dataset = out_dataset.add_column("num_correct", num_correct)
+
+    # get core dataset
+    results_grouped = {}
+    model_name = args.model_path
+    results_grouped["model"] = model_name
+    chat_template = (
+        "None" if not check_tokenizer_chat_template(tokenizer) else "tokenizer"
+    )
+    results_grouped["chat_template"] = chat_template
+
+    # print per subset and log into results_grouped file
+    results_file = open(os.path.join(args.output_path, "results.txt"), "w")
+    present_subsets = np.unique(subsets)
+    for subset in present_subsets:
+        subset_dataset = out_dataset.filter(lambda example: example["subset"] == subset)
+        # recompute "results" column for ties subset with different scoring method
+        if subset.lower() == "ties":
+            ties_subset_with_results, overall_score = process_single_model(
+                subset_dataset
+            )
+            subset_dataset = ties_subset_with_results
+
+            # Update the results for the ties subset in the original dataset
+            ties_indices = [
+                i for i, s in enumerate(out_dataset["subset"]) if s == "ties"
+            ]
+            out_dataset_df = out_dataset.to_pandas()
+            for i, ties_idx in enumerate(ties_indices):
+                out_dataset_df.at[ties_idx, "results"] = ties_subset_with_results[
+                    "results"
+                ][i]
+            out_dataset = Dataset.from_pandas(out_dataset_df)
+
+            print(f"{subset}: Overall score {overall_score}")
+            results_file.write(f"{subset}: Overall score {overall_score}\n")
+            results_grouped[subset] = overall_score
+        else:
+            num_correct = sum(subset_dataset["results"])
+            num_total = len(subset_dataset["results"])
+            print(f"{subset}: {num_correct}/{num_total} ({num_correct / num_total})")
+            results_file.write(
+                f"{subset}: {num_correct}/{num_total} ({num_correct / num_total})\n"
+            )
+            results_grouped[subset] = num_correct / num_total
+
+    # Save the first sample to JSON
+    with open(os.path.join(args.output_path, "first_sample.json"), "w") as f:
+        json.dump(out_dataset[0], f, indent=2)
+
+    logger.info("Saving output dataset")
+    out_dataset.save_to_disk(args.output_path)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    output_dir_exists = os.path.exists(args.output_path)
+    os.makedirs(args.output_path, exist_ok=True)
+    with open(os.path.join(args.output_path, "args.json"), "w") as f:
+        json.dump(vars(args), f, indent=2)
+
+    logger.info("Logging into HuggingFace")
+    setup(login_to_hf=True)
+
+    if args.seed:
+        logger.info(f"Setting random seed to {args.seed}")
+        set_seed(args.seed)
+
+    # This is hardcoded for https://huggingface.co/datasets/allenai/reward-bench-2
+    logger.info("No annotated dataset found, annotating completions")
+
+    reward_bench_dataset = load_dataset("allenai/reward-bench-2")
+    reward_bench_dataset = reward_bench_dataset["test"]
+
+    if args.debug:
+        logger.info("Debug mode: Only annotating completions the first 10 prompts")
+        reward_bench_dataset = reward_bench_dataset.select(range(10))
+
+    logger.info(f"Annotating {len(reward_bench_dataset)} samples")
+    run(reward_bench_dataset, args)

--- a/scripts/eval_judge_rewardbench.sbatch
+++ b/scripts/eval_judge_rewardbench.sbatch
@@ -1,28 +1,22 @@
 #!/bin/bash
+# shellcheck disable=SC2206
 #SBATCH --account=a-infra01-1
-#SBATCH --partition=debug
+#SBATCH --exclusive
+#SBATCH --cpus-per-task=288
+#SBATCH --nodes=1
+#SBATCH --gres=gpu:4
+#SBATCH --tasks-per-node=1
+#SBATCH --partition=normal
 #SBATCH --time=1:00:00
 #SBATCH --container-writable
 #SBATCH --job-name=judge_rewardbench
 #SBATCH --output=./logs/judge/rewardbench_%j.out
-#SBATCH --error=./logs/judge/rewardbench_%j.err
-#SBATCH --exclude=nid006438,nid006439,nid006440,nid006441,nid006442,nid006443,nid006444,nid006445,nid006446,nid006447,nid006448,nid006449,nid006450,nid006451,nid006461,nid006462,nid006868,nid006476,nid005557,nid006455,nid007122,nid007119,nid006513,nid005813,nid006454,nid006452,nid006457,nid005230,nid005248,nid007117
 #SBATCH --environment=activeuf_dev
-
-pip install resources/reward-bench
 
 python -m scripts.eval_judge_rewardbench \
     --model_path="Qwen/Qwen3-32B" \
     --output_path /iopsstor/scratch/cscs/smarian/data/judge_rewardbench/Qwen3-32B \
-    --max_tokens 24000 \
-    --model_class vllm \
-    --temperature 0.0 \
-    --top_p 0.1
-
-python -m scripts.eval_judge_rewardbench \
-    --model_path="meta-llama/Llama-3.3-70B-Instruct" \
-    --output_path /iopsstor/scratch/cscs/smarian/data/judge_rewardbench/Llama-3.3-70B-Instruct \
-    --max_tokens 24000 \
-    --model_class vllm \
+    --max_tokens 128 \
+    --model_class vllm_server \
     --temperature 0.0 \
     --top_p 0.1

--- a/scripts/eval_judge_rewardbench.sbatch
+++ b/scripts/eval_judge_rewardbench.sbatch
@@ -1,0 +1,28 @@
+#!/bin/bash
+#SBATCH --account=a-infra01-1
+#SBATCH --partition=debug
+#SBATCH --time=1:00:00
+#SBATCH --container-writable
+#SBATCH --job-name=judge_rewardbench
+#SBATCH --output=./logs/judge/rewardbench_%j.out
+#SBATCH --error=./logs/judge/rewardbench_%j.err
+#SBATCH --exclude=nid006438,nid006439,nid006440,nid006441,nid006442,nid006443,nid006444,nid006445,nid006446,nid006447,nid006448,nid006449,nid006450,nid006451,nid006461,nid006462,nid006868,nid006476,nid005557,nid006455,nid007122,nid007119,nid006513,nid005813,nid006454,nid006452,nid006457,nid005230,nid005248,nid007117
+#SBATCH --environment=activeuf_dev
+
+pip install resources/reward-bench
+
+python -m scripts.eval_judge_rewardbench \
+    --model_path="Qwen/Qwen3-32B" \
+    --output_path /iopsstor/scratch/cscs/smarian/data/judge_rewardbench/Qwen3-32B \
+    --max_tokens 24000 \
+    --model_class vllm \
+    --temperature 0.0 \
+    --top_p 0.1
+
+python -m scripts.eval_judge_rewardbench \
+    --model_path="meta-llama/Llama-3.3-70B-Instruct" \
+    --output_path /iopsstor/scratch/cscs/smarian/data/judge_rewardbench/Llama-3.3-70B-Instruct \
+    --max_tokens 24000 \
+    --model_class vllm \
+    --temperature 0.0 \
+    --top_p 0.1

--- a/scripts/eval_judge_rewardbench_multi_node.sbatch
+++ b/scripts/eval_judge_rewardbench_multi_node.sbatch
@@ -1,0 +1,96 @@
+#!/bin/bash
+# shellcheck disable=SC2206
+#SBATCH --account=a-infra01-1
+#SBATCH --exclusive
+#SBATCH --cpus-per-task=288
+#SBATCH --nodes=2
+#SBATCH --gres=gpu:4
+#SBATCH --tasks-per-node=1
+#SBATCH --partition=normal
+#SBATCH --time=6:00:00
+#SBATCH --container-writable
+#SBATCH --job-name=judge_rewardbench
+#SBATCH --output=./logs/judge/rewardbench_%j.out
+#SBATCH --environment=activeuf_dev
+
+export RAY_CGRAPH_get_timeout=300
+export VLLM_SERVER_CONCURRENCY_LIMIT=25
+num_nodes_per_instance=2
+
+# Getting the node names and assigning a head node
+nodes=$(scontrol show hostnames "$SLURM_JOB_NODELIST")
+nodes_array=($nodes)
+
+echo "nodes: ${nodes}"
+echo "nodes_array: ${nodes_array[*]}"
+
+head_node=${nodes_array[0]}
+head_node_ip=$(srun --overlap --nodes=1 --ntasks=1 -w "$head_node" hostname --ip-address)
+
+echo "Head node: $head_node"
+echo "Head node IP: $head_node_ip"
+
+export head_node_ip="$head_node_ip"
+export CUDA_VISIBLE_DEVICES=0,1,2,3
+
+# If we detect a space character in the head node IP, we'll convert it to an ipv4 address. This step is optional.
+if [[ "$head_node_ip" == *" "* ]]; then
+IFS=' ' read -ra ADDR <<<"$head_node_ip"
+if [[ ${#ADDR[0]} -gt 16 ]]; then
+  head_node_ip=${ADDR[1]}
+else
+  head_node_ip=${ADDR[0]}
+fi
+echo "IPV6 address detected. We split the IPV4 address as $head_node_ip"
+fi
+
+# Start head node
+port=6382
+head_address=$head_node_ip:$port
+export RAY_ADDRESS="$head_address"
+export VLLM_HOST_IP="$head_node_ip"
+
+echo "Head Address (set as RAY_ADDRESS): $head_address"
+echo "Head VLLM_HOST_IP (set for driver): $VLLM_HOST_IP"
+
+echo "Starting HEAD at $head_node at IP $head_node_ip"
+ray start --head \
+          --node-ip-address=$head_node_ip \
+          --port=$port \
+          --num-cpus=${SLURM_CPUS_PER_TASK} \
+          --num-gpus=4  \
+          --resources="{\"node:$head_node_ip\": 1}" \
+          --block & 
+sleep 10  
+
+# Start workers
+worker_num=$((SLURM_JOB_NUM_NODES - 1))
+for ((i = 1; i <= worker_num; i++)); do
+    node=${nodes_array[$i]}
+    node_ip=$(srun --nodes=1 --overlap --ntasks=1 -w "$node" hostname --ip-address)
+    echo "Starting WORKER $i at $node with IP $node_ip"
+
+    srun --nodes=1 \
+       --ntasks=1 \
+       --overlap \
+       -w "$node" \
+       env VLLM_HOST_IP="$node_ip" CUDA_VISIBLE_DEVICES="0,1,2,3" \
+       ray start --address $head_address \
+                 --node-ip-address="$node_ip" \
+                 --num-cpus ${SLURM_CPUS_PER_TASK} \
+                 --num-gpus 4 \
+                 --block &
+    sleep 5
+done
+sleep 10
+
+ray status
+
+python -u -m scripts.eval_judge_rewardbench \
+    --model_path="Qwen/Qwen3-235B-A22B" \
+    --output_path /iopsstor/scratch/cscs/smarian/data/judge_rewardbench/Qwen3-235B-A22B \
+    --max_tokens 24000 \
+    --model_class vllm_server \
+    --temperature 0.0 \
+    --top_p 0.1 \
+    --num_nodes 2

--- a/scripts/kill_vllm_server.sh
+++ b/scripts/kill_vllm_server.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "Searching for active vllm server processes..."
+PIDS=$(pgrep -f "vllm serve")
+
+if [ -z "$PIDS" ]; then
+    echo "No active vllm server processes found."
+    exit 0
+else
+    echo "Found vllm server processes with PIDs: $PIDS"
+    echo "Attempting to terminate them..."
+    pkill -f "vllm serve"
+    if [ $? -eq 0 ]; then
+        echo "Successfully terminated vllm server processes."
+    else
+        echo "Failed to terminate some vllm server processes."
+    fi
+fi

--- a/scripts/test_hardware_driver.py
+++ b/scripts/test_hardware_driver.py
@@ -1,0 +1,60 @@
+# Test PyTorch NCCL
+import torch
+import torch.distributed as dist
+dist.init_process_group(backend="nccl")
+local_rank = dist.get_rank() % torch.cuda.device_count()
+torch.cuda.set_device(local_rank)
+data = torch.FloatTensor([1,] * 128).to("cuda")
+dist.all_reduce(data, op=dist.ReduceOp.SUM)
+torch.cuda.synchronize()
+value = data.mean().item()
+world_size = dist.get_world_size()
+assert value == world_size, f"Expected {world_size}, got {value}"
+
+print("PyTorch NCCL is successful!")
+
+# Test PyTorch GLOO
+gloo_group = dist.new_group(ranks=list(range(world_size)), backend="gloo")
+cpu_data = torch.FloatTensor([1,] * 128)
+dist.all_reduce(cpu_data, op=dist.ReduceOp.SUM, group=gloo_group)
+value = cpu_data.mean().item()
+assert value == world_size, f"Expected {world_size}, got {value}"
+
+print("PyTorch GLOO is successful!")
+
+if world_size <= 1:
+    exit()
+
+# Test vLLM NCCL, with cuda graph
+from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
+
+pynccl = PyNcclCommunicator(group=gloo_group, device=local_rank)
+# pynccl is enabled by default for 0.6.5+,
+# but for 0.6.4 and below, we need to enable it manually.
+# keep the code for backward compatibility when because people
+# prefer to read the latest documentation.
+pynccl.disabled = False
+
+s = torch.cuda.Stream()
+with torch.cuda.stream(s):
+    data.fill_(1)
+    out = pynccl.all_reduce(data, stream=s)
+    value = out.mean().item()
+    assert value == world_size, f"Expected {world_size}, got {value}"
+
+print("vLLM NCCL is successful!")
+
+g = torch.cuda.CUDAGraph()
+with torch.cuda.graph(cuda_graph=g, stream=s):
+    out = pynccl.all_reduce(data, stream=torch.cuda.current_stream())
+
+data.fill_(1)
+g.replay()
+torch.cuda.current_stream().synchronize()
+value = out.mean().item()
+assert value == world_size, f"Expected {world_size}, got {value}"
+
+print("vLLM NCCL with cuda graph is successful!")
+
+dist.destroy_process_group(gloo_group)
+dist.destroy_process_group()

--- a/scripts/test_hardware_driver.sbatch
+++ b/scripts/test_hardware_driver.sbatch
@@ -1,0 +1,65 @@
+#!/bin/bash
+#SBATCH --job-name=dist-hw-test
+#SBATCH --account=a-infra01-1
+#SBATCH --nodes=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --gres=gpu:4
+#SBATCH --cpus-per-task=288
+#SBATCH --time=00:10:00
+#SBATCH --partition=normal
+#SBATCH --output=./logs/test_hardware_driver.out
+#SBATCH --environment=activeuf_dev
+#SBATCH --exclusive
+
+GPUS_PER_NODE=4
+SCRIPT_PATH=scripts/test_hardware_driver.py
+MASTER_PORT=${MASTER_PORT:-29505}
+export NCCL_DEBUG=${NCCL_DEBUG:-INFO}
+export TORCH_DISTRIBUTED_DEBUG=${TORCH_DISTRIBUTED_DEBUG:-DETAIL}
+
+set -euo pipefail
+
+echo "SLURM_JOBID        = $SLURM_JOB_ID"
+echo "SLURM_NODELIST     = $SLURM_JOB_NODELIST"
+echo "SLURM_NNODES       = $SLURM_NNODES"
+echo "SLURM_PROCS (total)= $SLURM_NTASKS"
+
+# Derive MASTER_ADDR as the first node hostname
+MASTER_ADDR=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n1)
+export MASTER_ADDR
+export MASTER_PORT
+
+echo "MASTER_ADDR=$MASTER_ADDR"
+echo "MASTER_PORT=$MASTER_PORT"
+
+echo "Torch / NCCL debug vars:"
+env | grep -E 'MASTER_|NCCL_|TORCH_DIST' || true
+
+# Sanity: ensure script exists
+if [[ ! -f $SCRIPT_PATH ]]; then
+  echo "Error: SCRIPT_PATH $SCRIPT_PATH not found" >&2
+  exit 1
+fi
+
+echo "Starting distributed test across $SLURM_NNODES nodes x $GPUS_PER_NODE GPUs"
+
+srun --ntasks=$SLURM_NNODES --ntasks-per-node=1 bash -c '
+  set -euo pipefail
+  echo "[Node $SLURM_NODEID] launching torchrun (rank launcher) on host $(hostname)"
+  torchrun \
+    --nnodes=$SLURM_NNODES \
+    --nproc-per-node='"$GPUS_PER_NODE"' \
+    --node-rank=$SLURM_NODEID \
+    --master_addr=$MASTER_ADDR \
+    --master_port=$MASTER_PORT \
+    '"$SCRIPT_PATH"'
+'
+
+status=$?
+if [[ $status -eq 0 ]]; then
+  echo "Distributed hardware communication sanity check succeeded." 
+else
+  echo "Distributed hardware communication sanity check FAILED with status $status" >&2
+fi
+
+exit $status


### PR DESCRIPTION
This PR introduces proper multi-node support by creating a ray cluster which can be connected to vLLM to load models across multiple nodes and also contains minor changes to update some old scripts to the latest code changes.

While not all models run, due to a mismatch between triton and xformers in the Dockerfile, since fixing this incompatability causes the Docker image build to fail, this branch can be merged for now.
Once xformers has better support for custom torch versions we should be able to install the latest xformers version pretty easily and get the last models running.

# List of Changes

- Update `generate_completions.py` to support data parallelism, and splitting the dataset
- Update `configs.py` use all principles by default and wait longer for vLLM server startup
- Update `convert_to_preference.py` to save datasets in the latest schema
- Update `combine_annotated_completions.py` to use argparse and make sure that the datasets are in the same order by sorting
- Update `get_raw_annotations.py` to work with vLLM server (multi-node)
- Add `run_annotations_multi_node.sh` to setup a ray cluster and run multi-node annotation
- Add `vllm_server` to load a model using a vLLM server (compatible with multiple nodes)
- Add `eval_judge_rewardbench.py`,  `eval_judge_rewardbench.sbatch`, and `eval_judge_rewardbench_multi_node.sbatch` to evaluate our custom judge on rewardbench 2
- Add `test_hardware_driver.py` and `test_hardware_driver.sbatch` to run hardware and driver test from [vLLM docs](https://docs.vllm.ai/en/v0.8.0/getting_started/troubleshooting.html#incorrect-hardware-driver)